### PR TITLE
Enhance/edge case highlighting

### DIFF
--- a/Eve.sublime-syntax
+++ b/Eve.sublime-syntax
@@ -11,7 +11,7 @@ variables:
 
 contexts:
   main:
-    - match: '^(```|~~~)$'
+    - match: '^\s*(```|~~~)\s*(?:eve)?\s*$'
       scope: keyword.other.eve
       push: block
 
@@ -20,7 +20,7 @@ contexts:
 
     - include: comment
 
-    - match: '^(```|~~~)$'
+    - match: '^\s*(```|~~~)\s*$'
       scope: keyword.other.eve
       pop: true
 
@@ -128,7 +128,7 @@ contexts:
       pop: true
 
   exit_block:
-    - match: '(?=^(```|~~~)$)'
+    - match: '(?=^\s*(```|~~~)\s*$)'
       scope: keyword.other.eve
       pop: true
 

--- a/Eve.sublime-syntax
+++ b/Eve.sublime-syntax
@@ -118,7 +118,7 @@ contexts:
       scope: 'keyword.operator.update.eve'
 
   misc_syntax:
-    - match: '[:.]'
+    - match: '[\[:.\]]'
 
   constants:
     - match: 'true|false'

--- a/Eve.sublime-syntax
+++ b/Eve.sublime-syntax
@@ -33,7 +33,7 @@ contexts:
       scope: keyword.other.eve
       pop: true
 
-    - match: 'search'
+    - match: '^\s*search'
       scope: keyword.section.search.eve
       push: search
 
@@ -153,8 +153,8 @@ contexts:
 
   search:
     - include: exit_block
-    - include: exit_clause
     - include: comment
+    - include: exit_clause
     - include: start_record
     - include: start_not
     - include: if_then_else
@@ -171,8 +171,8 @@ contexts:
 
   action:
     - include: exit_block
-    - include: exit_clause
     - include: comment
+    - include: exit_clause
     - include: start_record
     - include: update
     - include: misc_syntax

--- a/Eve.sublime-syntax
+++ b/Eve.sublime-syntax
@@ -15,6 +15,15 @@ contexts:
       scope: keyword.other.eve
       push: block
 
+    - match: '^\s*(```|~~~).*$'
+      scope: keyword.codeblock.eve
+      push: other_block
+
+  other_block:
+    - match: '^\s*(```|~~~).*$'
+      scope: keyword.codeblock.eve
+      pop: true
+
   block:
     - meta_scope: meta.block.eve
 


### PR DESCRIPTION
Fixes highlighting in a few edge case situations.

1. GFM supports an optional info string in code blocks, indicating what language the block is in. If the info string is empty or just "eve" we should render the block as Eve. Otherwise it's some other language.
2. Previously if a block had an opening fence had an info string it would be ignored completely, causing it's closing fence to be interpreted as the opening fence for a block with no info string.
3. Search as a keyword is required to be the start of it's line. There can also technically only be one search and one action per block, but we're mostly just worried about always highlighting reasonable things.
4. Misc syntax encompasses all the syntax which is important for writing but not for reading, so square brackets get tossed in too.

It'd also be nice to do a little work on auto-indentation, but I haven't the foggiest how that works in sublime. :man_shrugging: 

If this looks good to you, I think it's ready to hit package control after these changes.